### PR TITLE
feat: 🎸 add ability to animate terminal output

### DIFF
--- a/src/components/terminal-content.vue
+++ b/src/components/terminal-content.vue
@@ -1,87 +1,78 @@
 <style module>
-  .directory {
-    color: #48b9c7;
-    font-weight: 600;
-  }
-
-  .host {
-    color: #73c48f;
-    font-weight: 600;
-  }
-
-  .cursor {
-    animation: blink linear 1.4s infinite;
-    background-color: #fff;
-    display: inline-block;
-    height: 1em;
-    vertical-align: middle;
-    width: 1ch;
-  }
-
-  .line {
-    word-wrap: break-word;
-  }
-
-  @keyframes blink {
-    0% { opacity: 0; }
-    49% { opacity: 0; }
-    50% { opacity: 1; }
-    100% { opacity: 1; }
+  .container {
+    max-height: calc(100% - 0.6em);
+    overflow-y: auto;
+    padding: 0.3em;
   }
 </style>
 
 <script>
-function templateLine (h, text, { $style, props }) {
-  const formattedText = [text]
+import PopTerminalLine from './terminal-line.vue'
 
-  if (text.startsWith('$')) {
-    const newText = formattedText[0].substring(1)
-
-    formattedText.shift()
-
-    formattedText.unshift(newText)
-
-    formattedText.unshift('$ ')
-    formattedText.unshift(h('span', { class: $style.directory }, `${props.directory}`))
-    formattedText.unshift(':')
-    formattedText.unshift(h('span', { class: $style.host }, `${props.user}@${props.hostname}`))
+function regexLine (text) {
+  const DEFAULT = {
+    first: '$',
+    delay: '',
+    speed: '',
+    text: '',
+    last: '$'
   }
 
-  if (text.endsWith('$')) {
-    const lastFormattedText = formattedText[formattedText.length - 1]
+  if (text.trim() === '$') {
+    return DEFAULT
+  } else {
+    const matches = text.match(/^((?<first>\$|#)(?<delay>\d*)\|?(?<speed>\d*)(\$|#)?)?(?<text>.*?)(?<last>\$?)$/)
 
-    if (typeof lastFormattedText === 'string' && lastFormattedText.endsWith('$')) {
-      const newLastText = lastFormattedText.substring(0, lastFormattedText.length - 1)
-
-      formattedText.pop()
-
-      formattedText.push(newLastText)
+    if (matches != null) {
+      return Object.assign({}, DEFAULT, matches.groups)
+    } else {
+      return DEFAULT
     }
-
-    formattedText.push(h('span', { class: $style.cursor }, ''))
   }
-
-  return h('div', { class: $style.line }, formattedText)
 }
 
-function templateContent (h, vnode, ctx) {
-  const rawTextRows = vnode.text
-    .split('\n')
-    .filter((t) => /\S/.test(t))
+function trimText (text, first, last) {
+  return text
+    .substring((first && text.charAt(0) === ' ') ? 1 : 0)
+    .slice(0, last ? -1 : text.length)
+}
 
-  const firstWhitespaceLength = (rawTextRows[0].match(/^\s*/)[0] || '').length
+export function mapLineToObject (rawText) {
+  const rawParsed = regexLine(rawText)
 
-  return rawTextRows
-    .map((r) => r.substring(firstWhitespaceLength))
-    .map((r) => templateLine(h, r, ctx))
+  const prompt = (rawText !== '$' && rawParsed.first === '$')
+  const cursor = (rawParsed.last === '$')
+  const text = trimText(rawParsed.text, rawParsed.first, rawParsed.last)
+  const delay = Number(rawParsed.delay || 0)
+  const speed = (rawParsed.first === '$' && text !== '')
+    ? Number(rawParsed.speed || 60)
+    : 0
+
+  return { prompt, cursor, text, delay, speed }
+}
+
+function lineProps (content, line) {
+  return {
+    animate: content.animate,
+    cursor: line.cursor,
+    directory: content.directory,
+    hostname: content.hostname,
+    prompt: line.prompt,
+    text: line.text,
+    speed: line.speed,
+    user: content.user
+  }
 }
 
 export default {
   name: 'PopTerminalContent',
 
-  functional: true,
-
   props: {
+    animate: {
+      type: Boolean,
+      default: false
+    },
+
     directory: {
       type: String,
       default: '~'
@@ -92,18 +83,116 @@ export default {
       default: 'pop-os'
     },
 
+    loop: {
+      type: Boolean,
+      default: false
+    },
+
     user: {
       type: String,
       default: 'pop-os'
     }
   },
 
-  render (h, ctx) {
-    const children = ctx.children
-      .map((vnode) => templateContent(h, vnode, ctx))
-      .reduce((a, nodes = []) => [...a, ...nodes], [])
+  data () {
+    return {
+      currentLine: 0,
+      finished: !this.animate
+    }
+  },
 
-    return h('div', null, children)
+  computed: {
+    firstLineDelay () {
+      if (this.lineObjects[0] != null) {
+        return this.lineObjects[0].delay
+      } else {
+        return 0
+      }
+    },
+
+    nextLineDelay () {
+      if (this.lineObjects[this.currentLine] != null) {
+        return this.lineObjects[this.currentLine].delay
+      } else {
+        return 0
+      }
+    },
+
+    hasAnimatedLines () {
+      return this.lineObjects
+        .some((l) => (l.delay !== 0 || l.speed !== 0))
+    },
+
+    lineObjects () {
+      return this.linesOfText.map(mapLineToObject)
+    },
+
+    linesOfText () {
+      if (this.$slots.default[0] != null) {
+        const rawTextRows = this.$slots.default[0].text
+          .split('\n')
+          .filter((t) => /\S/.test(t))
+
+        const firstWhitespaceLength = (rawTextRows[0].match(/^\s*/)[0] || '').length
+
+        return rawTextRows
+          .map((r) => r.substring(firstWhitespaceLength))
+      } else {
+        return 0
+      }
+    }
+  },
+
+  mounted () {
+    if (this.animate) {
+      this.reset()
+    } else {
+      this.currentLine = this.linesOfText.length
+    }
+  },
+
+  updated () {
+    this.$el.scroll({
+      top: this.$el.scrollHeight,
+      behavior: 'instant'
+    })
+  },
+
+  methods: {
+    draw () {
+      if (this.currentLine < this.linesOfText.length && !this.finished) {
+        this.renderTimeout = setTimeout(() => {
+          this.currentLine += 1
+        }, this.nextLineDelay)
+      } else {
+        if (this.loop) {
+          this.renderTimeout = setTimeout(() => {
+            this.reset()
+          }, this.firstLineDelay)
+        } else {
+          this.$emit('complete')
+        }
+      }
+    },
+
+    reset () {
+      this.currentLine = 0
+      this.finished = false
+
+      this.draw()
+    }
+  },
+
+  render (h) {
+    const children = this.lineObjects
+      .slice(0, this.currentLine)
+      .map((line) => h(PopTerminalLine, {
+        on: { complete: this.draw },
+        props: lineProps(this, line)
+      }))
+
+    return h('div', { class: this.$style.container }, children)
   }
-}
+}; // eslint-disable-line semi
+// Needed to make Vue test utils and require-extension-hooks work correctly
 </script>

--- a/src/components/terminal-line.vue
+++ b/src/components/terminal-line.vue
@@ -1,0 +1,141 @@
+<style module>
+  .directory {
+    color: #48b9c7;
+    font-weight: 600;
+  }
+
+  .host {
+    color: #73c48f;
+    font-weight: 600;
+  }
+
+  .cursor {
+    animation: blink linear 1.4s infinite;
+    background-color: #fff;
+    display: inline-block;
+    height: 1em;
+    vertical-align: middle;
+    width: 1ch;
+  }
+
+  .line {
+    word-wrap: break-word;
+  }
+
+  @keyframes blink {
+    0% { opacity: 0; }
+    49% { opacity: 0; }
+    50% { opacity: 1; }
+    100% { opacity: 1; }
+  }
+</style>
+
+<script>
+export default {
+  name: 'PopTerminalLine',
+
+  props: {
+    animate: {
+      type: Boolean,
+      default: false
+    },
+
+    cursor: {
+      type: Boolean,
+      default: false
+    },
+
+    directory: {
+      type: String,
+      default: '~'
+    },
+
+    hostname: {
+      type: String,
+      default: 'pop-os'
+    },
+
+    prompt: {
+      type: Boolean,
+      default: false
+    },
+
+    text: {
+      type: String,
+      default: ''
+    },
+
+    speed: {
+      type: Number,
+      default: 0
+    },
+
+    user: {
+      type: String,
+      default: 'pop-os'
+    }
+  },
+
+  data () {
+    return {
+      currentText: (!this.animate || this.speed === 0 ? this.text : ''),
+      finished: (this.speed === 0),
+      renderTimeout: null
+    }
+  },
+
+  mounted () {
+    if (this.animate && this.speed !== 0) {
+      this.draw()
+    } else {
+      this.$emit('complete')
+    }
+  },
+
+  beforeDestroy () {
+    clearTimeout(this.renderTimeout)
+  },
+
+  methods: {
+    draw () {
+      if (!this.finished) {
+        const nextCharacter = this.text.charAt(this.currentText.length)
+
+        if (nextCharacter !== '') {
+          this.currentText += nextCharacter
+        } else {
+          this.finished = true
+        }
+      }
+
+      if (!this.finished) {
+        this.renderTimeout = setTimeout(this.draw.bind(this), this.timeoutDelay())
+      } else {
+        this.$emit('complete')
+      }
+    },
+
+    timeoutDelay () {
+      return Math.round((Math.random() * this.speed) / 2) + this.speed
+    }
+  },
+
+  render (h) {
+    const formattedText = [this.currentText]
+
+    if (this.prompt) {
+      formattedText.unshift('$ ')
+      formattedText.unshift(h('span', { class: this.$style.directory }, `${this.directory}`))
+      formattedText.unshift(':')
+      formattedText.unshift(h('span', { class: this.$style.host }, `${this.user}@${this.hostname}`))
+    }
+
+    if (this.cursor) {
+      formattedText.push(h('span', { class: this.$style.cursor }, ''))
+    }
+
+    return h('div', { class: this.$style.line }, formattedText)
+  }
+}; // eslint-disable-line semi
+// Needed to make Vue test utils and require-extension-hooks work correctly
+</script>

--- a/src/components/terminal.stories.js
+++ b/src/components/terminal.stories.js
@@ -1,4 +1,4 @@
-import { withKnobs, text } from '@storybook/addon-knobs/vue'
+import { withKnobs, boolean, text } from '@storybook/addon-knobs/vue'
 import { storiesOf } from '@storybook/vue'
 
 import PopTerminalContent from './terminal-content.vue'
@@ -185,6 +185,87 @@ storiesOf('Apps|Terminal', module)
             qXtUussttkyo2SKb18b32UnvV7NYjSrptqnQSO39lZESCWxnSpVlmDtEZriPFHx993YHs2iF36Ie
             1El5wZHL1owE/mmnThGe2EXn5DrXYh/6NFCw0G0CNFSwM1rC+qnqY4g9jGf6krjRYfYU1wSf1C0z
             VPb+S2mPojA1vvqXm7FE/Qyx7fbqL0eXd5lu6azcc1xdxPixW8yVpAeVTUCuLqM4cCzzdPvIHFhK
+          </pop-terminal-content>
+        </pop-terminal>
+      </div>
+    `
+  }))
+  .add('with animations', () => ({
+    components: { PopTerminal, PopTerminalContent },
+    props: {
+      directory: { default: text('directory', '~') },
+      hostname: { default: text('hostname', 'pop-os') },
+      loop: { default: boolean('loop', true) },
+      user: { default: text('user', 'pop-os') }
+    },
+    template: `
+      <div
+        style="height:30vh;width:80vw;"
+      >
+        <pop-terminal
+          style="height:300px;"
+          :directory="directory"
+          :hostname="hostname"
+          :user="user"
+        >
+          <pop-terminal-content
+            :animate="true"
+            :directory="directory"
+            :hostname="hostname"
+            :loop="loop"
+            :user="user"
+          >
+            $1000|200$ sudo apt update
+            #40# Hit:1 http://us.archive.ubuntu.com/ubuntu bionic InRelease
+            #20# Ign:2 http://dl.google.com/linux/chrome/deb stable InRelease
+            #20# Get:3 http://packages.elementary.io/appcenter bionic InRelease [5,894 B]
+            #40# Get:4 http://us.archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+            #20# Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+            #20# Get:6 http://us.archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+            #30# Hit:8 http://dl.google.com/linux/chrome/deb stable Release
+            #20# Hit:9 http://ppa.launchpad.net/ansible/ansible/ubuntu bionic InRelease
+            #20# Hit:7 https://packagecloud.io/github/git-lfs/ubuntu bionic InRelease
+            #20# Get:10 http://packages.elementary.io/appcenter bionic/main amd64 DEP-11 Metadata [232 kB]
+            #20# Hit:11 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic InRelease
+            #20# Get:12 http://us.archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [853 kB]
+            #10# Get:14 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic InRelease [20.8 kB]
+            #20# Get:15 http://us.archive.ubuntu.com/ubuntu bionic-updates/main i386 Packages [642 kB]
+            #20# Get:16 http://security.ubuntu.com/ubuntu bionic-security/main i386 Packages [437 kB]
+            #70# Get:17 http://us.archive.ubuntu.com/ubuntu bionic-updates/main Translation-en [298 kB]
+            #20# Get:18 http://us.archive.ubuntu.com/ubuntu bionic-updates/main amd64 DEP-11 Metadata [295 kB]
+            #20# Hit:19 http://ppa.launchpad.net/system76-dev/stable/ubuntu bionic InRelease
+            #20# Get:20 http://us.archive.ubuntu.com/ubuntu bionic-updates/main DEP-11 48x48 Icons [73.8 kB]
+            #20# Get:21 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [636 kB]
+            #40# Get:22 http://us.archive.ubuntu.com/ubuntu bionic-updates/main DEP-11 64x64 Icons [140 kB]
+            #20# Get:23 http://security.ubuntu.com/ubuntu bionic-security/main Translation-en [208 kB]
+            #20# Get:24 http://us.archive.ubuntu.com/ubuntu bionic-updates/main DEP-11 128x128 Icons [348 kB]
+            #20# Get:25 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic/main Sources [19.4 kB]
+            #20# Get:26 http://security.ubuntu.com/ubuntu bionic-security/main amd64 DEP-11 Metadata [38.5 kB]
+            #20# Get:27 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,049 kB]
+            #20# Get:28 http://security.ubuntu.com/ubuntu bionic-security/main DEP-11 48x48 Icons [17.6 kB]
+            #20# Get:29 http://security.ubuntu.com/ubuntu bionic-security/main DEP-11 64x64 Icons [41.5 kB]
+            #20# Get:30 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe i386 Packages [1,008 kB]
+            #20# Get:31 http://security.ubuntu.com/ubuntu bionic-security/main DEP-11 128x128 Icons [97.7 kB]
+            #20# Get:32 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic/main amd64 Packages [36.0 kB]
+            #20# Get:33 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [324 kB]
+            #20# Get:34 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 DEP-11 Metadata [264 kB]
+            #20# Get:35 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 DEP-11 Metadata [42.1 kB]
+            #20# Get:36 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe DEP-11 48x48 Icons [199 kB]
+            #20# Get:37 http://security.ubuntu.com/ubuntu bionic-security/universe DEP-11 48x48 Icons [16.4 kB]
+            #20# Get:38 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe DEP-11 64x64 Icons [440 kB]
+            #20# Get:39 http://security.ubuntu.com/ubuntu bionic-security/universe DEP-11 64x64 Icons [111 kB]
+            #20# Get:40 http://us.archive.ubuntu.com/ubuntu bionic-updates/universe DEP-11 128x128 Icons [977 kB]
+            #20# Get:41 http://security.ubuntu.com/ubuntu bionic-security/universe DEP-11 128x128 Icons [181 kB]
+            #20# Get:42 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic/main i386 Packages [35.8 kB]
+            #20# Get:43 http://us.archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 DEP-11 Metadata [2,464 B]
+            #20# Get:44 http://us.archive.ubuntu.com/ubuntu bionic-backports/universe amd64 DEP-11 Metadata [8,284 B]
+            #600# Get:45 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 DEP-11 Metadata [2,464 B]
+            #200# Fetched 9,351 kB in 2s (4,110 kB/s)
+            #1200# Reading package lists... Done
+            #100# Building dependency tree
+            #100# Reading state information... Done
+            2 packages can be upgraded. Run 'apt list --upgradable' to see them.
+            $800$ clear
           </pop-terminal-content>
         </pop-terminal>
       </div>

--- a/src/components/terminal.vue
+++ b/src/components/terminal.vue
@@ -17,11 +17,12 @@
     box-sizing: border-box;
     color: #f2f2f2;
     display: block;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     font-family: "Fira Mono", "Ubuntu Mono", "Ubuntu Monospace", "Menlo", "Consolas", "Roboto Mono", "Noto Mono", "Oxygen Mono", "Liberation Mono", monospace;
     font-size: 0.9rem;
+    height: 100%;
     line-height: 1.2;
-    padding: 0.3em;
+    overflow: hidden;
     width: 100%;
   }
 </style>

--- a/src/components/window-container.vue
+++ b/src/components/window-container.vue
@@ -19,6 +19,7 @@ export default {
     box-shadow: var(--pop-shadow-window);
     display: flex;
     flex-direction: column;
+    flex-wrap: nowrap;
     justify-content: flex-start;
   }
 </style>

--- a/test/spec/components/terminal-content.js
+++ b/test/spec/components/terminal-content.js
@@ -1,0 +1,61 @@
+/**
+ * pop-vue/test/spec/components/terminal-content.js
+ * Tests the terminal content parser
+ */
+
+import test from 'ava'
+
+import { mapLineToObject } from '../../../src/components/terminal-content.vue'
+
+test('a line with only "$" is a cursor line', (t) => {
+  const res = mapLineToObject('$')
+
+  t.false(res.prompt)
+  t.true(res.cursor)
+  t.is(res.text, '')
+})
+
+test('identifies a prompt line correctly', (t) => {
+  const res = mapLineToObject('$ sudo apt update')
+
+  t.true(res.prompt)
+  t.is(res.text, 'sudo apt update')
+})
+
+test('identifies a prompt line with cursor correctly', (t) => {
+  const res = mapLineToObject('$ sudo apt update $')
+
+  t.true(res.prompt)
+  t.true(res.cursor)
+  t.is(res.text, 'sudo apt update')
+})
+
+test('identifies delay on a prompt line', (t) => {
+  const res = mapLineToObject('$20$ sudo apt update')
+
+  t.true(res.prompt)
+  t.is(res.delay, 20)
+})
+
+test('identifies speed on a prompt line', (t) => {
+  const res = mapLineToObject('$|312$ console output line here')
+
+  t.is(res.text, 'console output line here')
+  t.is(res.speed, 312)
+})
+
+test('identifies speed and delay on a prompt line', (t) => {
+  const res = mapLineToObject('$400|312$ console output line here')
+
+  t.is(res.text, 'console output line here')
+  t.is(res.delay, 400)
+  t.is(res.speed, 312)
+})
+
+test('regular text has no prompt or cursor', (t) => {
+  const res = mapLineToObject('output here')
+
+  t.false(res.prompt)
+  t.false(res.cursor)
+  t.is(res.text, 'output here')
+})


### PR DESCRIPTION
Add some special syntax to pop-terminal-content to allow animating each line. I did not add any documentation to this, but you can look in the storybook to get the syntax. I would like to add an actual doc page for `pop-terminal` and `pop-terminal-content`, but I'll leave that for another PR unless someone wants me to.