### PR TITLE
fix: 🐛 update terminal content parsing to support firefox

### DIFF
--- a/src/components/terminal-content.vue
+++ b/src/components/terminal-content.vue
@@ -21,10 +21,11 @@ function regexLine (text) {
   if (text.trim() === '$') {
     return DEFAULT
   } else {
-    const matches = text.match(/^((?<first>\$|#)(?<delay>\d*)\|?(?<speed>\d*)(\$|#)?)?(?<text>.*?)(?<last>\$?)$/)
+    const matches = text.match(/^((\$|#)(\d*)\|?(\d*)(\$|#)?)?(.*?)(\$?)$/)
 
     if (matches != null) {
-      return Object.assign({}, DEFAULT, matches.groups)
+      const [,, first, delay, speed,, text, last] = matches
+      return Object.assign({}, DEFAULT, { first, delay, speed, text, last })
     } else {
       return DEFAULT
     }


### PR DESCRIPTION
Because firefox does not support named groups in regex.